### PR TITLE
0.0.6 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 0.0.6
+==================
+1. Added the json serialization mode. This could be specified by `hash_method` when calling `persistf`.
+2. If a function is specified to be `cache=ptd.READONLY`, no file lock will be used (to avoid unncessary conflict).
+
 ## 0.0.5
 ==================
 1. `lock_granularity` can be set differently for each function.

--- a/persist_to_disk/__init__.py
+++ b/persist_to_disk/__init__.py
@@ -45,6 +45,9 @@ def persistf(freq=None, hashsize: int = None,
             Defaults to None (equivalent to CACHE).
         lock_granularity (str, optional):
             Granularity of the lock. Can be either 'function', 'call' or 'global'.
+        hash_method (str, optional):
+            Method to hash the inputs. Can be either 'pickle' or 'json'.
+            Defaults to 'pickle'.
     """
     def _decorator(func):
         return persist_func_version(func, config,

--- a/persist_to_disk/__init__.py
+++ b/persist_to_disk/__init__.py
@@ -16,7 +16,8 @@ config = Config()
 def persistf(freq=None, hashsize: int = None,
              skip_kwargs: List[str] = None, expand_dict_kwargs: Union[List[str], str] = None,
              groupby: List[str] = None,
-             switch_kwarg: str = 'cache_switch', cache: int = None, lock_granularity:str=None):
+             switch_kwarg: str = 'cache_switch', cache: int = None, lock_granularity:str=None,
+             hash_method='pickle'):
     """Base decorator that does all the heavy-lifting for caching, taking additional arguments.
 
     Args:
@@ -49,45 +50,9 @@ def persistf(freq=None, hashsize: int = None,
         return persist_func_version(func, config,
                                     freq=freq, hashsize=hashsize,
                                     skip_kwargs=skip_kwargs, expand_dict_kwargs=expand_dict_kwargs,
-                                    groupby=groupby, switch_kwarg=switch_kwarg, cache=cache, lock_granularity=lock_granularity)
+                                    groupby=groupby, switch_kwarg=switch_kwarg, cache=cache, lock_granularity=lock_granularity,
+                                    hash_method=hash_method)
     return _decorator
-
-
-def persist(freq=None, hashsize: int = None,
-            skip_kwargs: List[str] = None, expand_dict_kwargs: Union[List[str], str] = None,
-            groupby: List[str] = None,
-            switch_kwarg: str = 'cache_switch', cache: int = None):
-    """Base decorator that does all the heavy-lifting for caching, taking additional arguments.
-
-    Args:
-        freq (_type_, optional): unused for now. Defaults to None.
-        hashsize (int, optional): Calls/Inputs to func are hashed into *hashsize* buckets.
-            Defaults to what's set in config.
-        skip_kwargs (List[str], optional): these kwargs are ignored (e.g. gpu_id, verbose, ...).
-            Defaults to empty list.
-        expand_dict_kwargs (Union[List[str], str], optional): arguments to expand.
-            Applies to arguments to *func* that are dictionaries.
-            If str, it must be `all` which means all dictionaries are recursively expanded.
-            Note that any calls with un-expanded dictionary arguments will fail.
-            Defaults to None.
-        groupby (List[str], optional): Create several levels of cache.
-            For example, if groupby=['dataset'], then calls with each
-            dataset will be stored in a separate folder.
-            Defaults to None.
-        switch_kwarg (str, optional):
-            A switch to turn on/off the caching mechanism.
-            Takes value in {NOCACHE, CACHE, RECACHE, READONLY}
-            Defaults to 'cache_switch'.
-        cache (int, optional):
-            Same as switch_kwarg but this is a function-level setting (not call level).
-            Useful for recaching/debugging purposes.
-            Defaults to None (equivalent to CACHE).
-    """
-    return lambda func: Persister(func, config,
-                                  freq=freq, hashsize=hashsize,
-                                  skip_kwargs=skip_kwargs, expand_dict_kwargs=expand_dict_kwargs,
-                                  groupby=groupby, switch_kwarg=switch_kwarg, cache=cache)
-
 
 def clear_locks(clear=False):
     """This function clears ALL locks for your project, if any.
@@ -150,13 +115,12 @@ def manual_cache(key: str, obj: Any = None, write: bool = False) -> Any:
 
 __all__ = [
     'config',
-    'persist',
     'clear_locks',
     'persistf',
     'get_caller_cache_path',
     'manual_cache'
 ]
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 __author__ = 'Zhen Lin'
 __credits__ = ''

--- a/persist_to_disk/persister.py
+++ b/persist_to_disk/persister.py
@@ -114,6 +114,10 @@ def _persist_write(cache_path, key, closure_func: Callable[[], Any], alt_roots, 
 
 def _persist_write_if_necessary(cache_path, key, closure_func: Callable[[], Any],
                                 readonly=False, alt_roots=None, *, lock_path):
+    if readonly:
+        res = _utils.read_pickle(cache_path)
+        assert key in res, f"In readonly mode, but there is no existing cache {key}."
+        return res[key]
     try:
         _print(
             f"persist_to_disk: {cache_path} exists? : {os.path.isfile(cache_path)}.")

--- a/persist_to_disk/persister.py
+++ b/persist_to_disk/persister.py
@@ -2,8 +2,7 @@
 """
 import copy
 import functools
-#import time
-#import sys
+import json
 import glob
 import hashlib
 import inspect
@@ -57,6 +56,23 @@ def get_persist_dir_from_paths(base_dir: str, file_path: str, project_path: str)
         persist_dir = file_path.replace(
             project_path, os.path.normpath(base_dir))
     return os.path.normpath(persist_dir)
+
+
+def _hash_tuple_json(k):
+    def json_default(thing):
+        if inspect.isclass(thing):
+            return str(thing)
+        raise TypeError(f"object of type {type(thing).__name__} not serializable")
+    def json_dumps(thing):
+        return json.dumps(
+            thing,
+            default=json_default,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=None,
+            separators=(',', ':'),
+        )
+    return int(hashlib.md5(json_dumps(dict(k)).encode('utf-8')).hexdigest(), 16)
 
 
 def _hash(k):
@@ -156,7 +172,7 @@ def _clean_kwargs(full_kwargs, skip_kwargs, expand_dict_kwargs):
     return full_kwargs
 
 
-def _get_hashed_path_and_key(cache_dir, full_kwargs, hashsize, groupby):
+def _get_hashed_path_and_key(cache_dir, full_kwargs, hashsize, groupby, hash_method):
     for k in groupby:
         if isinstance(k, tuple):
             dirname = "$$".join([str(full_kwargs.pop(kk)) for kk in k])
@@ -165,7 +181,8 @@ def _get_hashed_path_and_key(cache_dir, full_kwargs, hashsize, groupby):
         cache_dir = os.path.join(cache_dir, dirname)
     _utils.make_dir_if_necessary(cache_dir)
     key = tuple(sorted(six.iteritems(full_kwargs), key=lambda x: x[0]))
-    hashed_path = os.path.join(cache_dir, f"{_hash(key) % hashsize}.pkl")
+    hash_func = {'pickle': _hash, 'json': _hash_tuple_json}[hash_method]
+    hashed_path = os.path.join(cache_dir, f"{hash_func(key) % hashsize}.pkl")
     return hashed_path, key
 
 
@@ -198,7 +215,9 @@ class Persister():
                  freq=None, hashsize: int = None,
                  skip_kwargs: List[str] = None, expand_dict_kwargs: Union[List[str], str] = None,
                  groupby: List[str] = None,
-                 switch_kwarg: str = 'cache_switch', cache: int = None, lock_granularity:str=None):
+                 switch_kwarg: str = 'cache_switch', cache: int = None, lock_granularity:str=None,
+                 hash_method='pickle'):
+        assert hash_method in {'pickle', 'json'}
         functools.update_wrapper(self, func)
         self.__defaults__ = six.get_function_defaults(func)
         if skip_kwargs is None:
@@ -227,6 +246,7 @@ class Persister():
         self.expand_dict_kwargs = expand_dict_kwargs
         self.groupby = groupby
         self.lock_granularity = lock_granularity
+        self.hash_method = hash_method
 
         # Get the cache_dir straight
         self.cache_dir = get_persist_dir_from_paths(
@@ -256,7 +276,7 @@ class Persister():
         _cleaned = _clean_kwargs(
             full_kwargs, self.skip_kwargs, self.expand_dict_kwargs)
         hashed_path, key = _get_hashed_path_and_key(
-            self.cache_dir, _cleaned, self.hashsize, self.groupby)
+            self.cache_dir, _cleaned, self.hashsize, self.groupby, self.hash_method)
         lock_path = _get_lock_path(hashed_path, self.config, self.lock_granularity)
 
         if cache_switch == RECACHE:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 
 setup_args = dict(
     name='persist_to_disk',
-    version='0.0.5',
+    version='0.0.6',
     description='Persist expensive operations on disk.',
     long_description_content_type="text/markdown",
     long_description=README + '\n\n' + HISTORY,


### PR DESCRIPTION
## 0.0.6
==================
1. Added the json serialization mode. This could be specified by `hash_method` when calling `persistf`.
2. If a function is specified to be `cache=ptd.READONLY`, no file lock will be used (to avoid unncessary conflict).
